### PR TITLE
Change service name to Pimcore\Navigation\Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To do so, add following service definition to your application:
  
 ```yaml
 
-pimcore.navigation.builder:
+Pimcore\Navigation\Builder:
     class: FrontendPermissionToolkitBundle\CoreExtensions\Navigation\Builder
     arguments: ['@pimcore.http.request_helper']
     public: false


### PR DESCRIPTION
Pimcore core has changed the name of the service to `Pimcore\Navigation\Builder`. `pimcore.navigation.builder` does not get called in current Pimcore version.