### PR TITLE
Making bundle.frontendpermissiontoolkit.service public and autowired

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,3 +1,5 @@
 services:
     bundle.frontendpermissiontoolkit.service:
         class: FrontendPermissionToolkitBundle\Service
+        autowire: true
+        public: true


### PR DESCRIPTION
Using bundle.frontendpermissiontoolkit.service throw an error :

`The "bundle.frontendpermissiontoolkit.service" service or alias has been removed or inlined when the container was compiled.`

This PR fix this as far as i can tell.