### PR TITLE
fix: permission roles trait service error

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,6 +1,7 @@
 services:
 
     FrontendPermissionToolkitBundle\Service:
+        public: true
         autoconfigure: true
         autowire: true
 


### PR DESCRIPTION
The "FrontendPermissionToolkitBundle\Service" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.
Fixed by making service configuration public