### PR TITLE
fix: navigation builder override not working

### DIFF
--- a/src/CoreExtensions/Navigation/Builder.php
+++ b/src/CoreExtensions/Navigation/Builder.php
@@ -59,7 +59,7 @@ class Builder extends \Pimcore\Navigation\Builder
     /**
      * @inheritdoc
      */
-    protected function getChilds(Document $parentDocument)
+    protected function getChildren(Document $parentDocument): array
     {
         $children = $parentDocument->getChildren();
 


### PR DESCRIPTION
Caused by navigation builder using getChilds instead of getChildren method used by Pimcore navigation builder.
Fixed by renaming method and adding return typehint.