### PR TITLE
cleanup: refactored service logic

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Pimcore
  *
@@ -18,16 +19,18 @@ use FrontendPermissionToolkitBundle\CoreExtensions\ClassDefinitions\DynamicPermi
 use FrontendPermissionToolkitBundle\CoreExtensions\ClassDefinitions\PermissionManyToManyRelation;
 use FrontendPermissionToolkitBundle\CoreExtensions\ClassDefinitions\PermissionManyToOneRelation;
 use FrontendPermissionToolkitBundle\CoreExtensions\ClassDefinitions\PermissionResource;
+use Pimcore\Model\AbstractModel;
+use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\Concrete;
-use Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks;
+use Pimcore\Model\DataObject\Objectbrick;
 
-class Service {
-
+class Service
+{
     const DENY = "deny";
     const ALLOW = "allow";
     const INHERIT = "inherit";
 
-    private $permissionCache = array();
+    private $permissionCache = [];
 
     /**
      * returns array of all permission resources of given object
@@ -41,91 +44,62 @@ class Service {
      * @param Concrete $object
      * @return array
      */
-    public function getPermissions(Concrete $object, array $visitedIds = []): array {
-
-        if(isset($this->permissionCache[$object->getId()])) {
+    public function getPermissions(Concrete $object, array $visitedIds = []): array
+    {
+        if (isset($this->permissionCache[$object->getId()])) {
             return $this->permissionCache[$object->getId()];
         }
 
-        if(isset($visitedIds[$object->getId()])) {
+        if (isset($visitedIds[$object->getId()])) {
             return [];
         } else {
             $visitedIds[$object->getId()] = true;
         }
 
-
-        $permissions = [];
-
-        $class = $object->getClass();
-        $fieldDefinitions = $class->getFieldDefinitions();
-
-        $permissionObjects = [];
+        $fieldDefinitions = $object->getClass()->getFieldDefinitions();
+        $permissions = $permissionObjects = [];
 
         // get permission resources directly in given object
-        foreach($fieldDefinitions as $fd) {
-            if($fd instanceof PermissionManyToManyRelation) {
-                $permissionObjects = array_merge($permissionObjects, $object->{'get' . $fd->getName()}());
-            }
-            if($fd instanceof PermissionManyToOneRelation) {
-                $href = $object->{'get' . $fd->getName()}();
-                if($href) {
-                    $permissionObjects[] = $href;
-                }
-            }
-
-            if($fd instanceof PermissionResource) {
-                $permissions[$fd->getName()] = $object->{'get' . $fd->getName()}();
-            }
-
-            if($fd instanceof DynamicPermissionResource) {
-                $permissions = array_merge($permissions, $object->{'get' . $fd->getName()}());
-            }
-
-            if($fd instanceof Objectbricks) {
-                $bricks = $object->{'get' . $fd->getName()}();
-                foreach($bricks->getBrickGetters() as $getter) {
-                    $brick = $bricks->$getter();
-
-                    if($brick) {
-                        $brickFieldDefinitions = $brick->getDefinition()->getFieldDefinitions();
-                        foreach($brickFieldDefinitions as $bfd) {
-                            if($bfd instanceof PermissionManyToManyRelation) {
-                                $permissionObjects = array_merge($permissionObjects, $brick->{'get' . $bfd->getName()}());
-                            }
-                            if($bfd instanceof PermissionManyToOneRelation) {
-                                $href = $object->{'get' . $bfd->getName()}();
-                                if($href) {
-                                    $permissionObjects[] = $href;
-                                }
-                            }
-                            if($bfd instanceof PermissionResource) {
-                                $permissions[$bfd->getName()] = $brick->{'get' . $bfd->getName()}();
-                            }
-
-                            if($fd instanceof DynamicPermissionResource) {
-                                $permissions = array_merge($permissions, $brick->{'get' . $fd->getName()}());
-                            }
-                        }
-                    }
-                }
-            }
+        foreach ($fieldDefinitions as $fieldDefinition) {
+            [$fieldPermissions, $fieldPermissionObjects] = $this->getPermissionsByFieldDefinition($object, $fieldDefinition);
+            $permissions = array_merge($permissions, $fieldPermissions);
+            $permissionObjects = array_merge($permissionObjects, $fieldPermissionObjects);
         }
 
-        // get permission resources from linked objects and merge them with permissions of given object
-        // - when permission is set to allow / deny directly in object, this is always used
-        // - otherwise optimistic merging is used -> once one permission is allowed, it stays that way
+        // get permission resources from related objects and merge them with permissions of base object
         $mergedPermissions = $permissions;
-        foreach($permissionObjects as $permissionObject) {
+        foreach ($permissionObjects as $permissionObject) {
             $objectPermissions = $this->getPermissions($permissionObject, $visitedIds);
-
-            foreach($objectPermissions as $key => $value) {
-                if(($permissions[$key] == self::INHERIT || !array_key_exists($key, $permissions)) && $mergedPermissions[$key] != self::ALLOW) {
-                    $mergedPermissions[$key] = $value;
-                }
-            }
+            $mergedPermissions = $this->mergeNestedObjectPermissions($mergedPermissions, $permissions, $objectPermissions);
         }
 
         $this->permissionCache[$object->getId()] = $mergedPermissions;
+        return $mergedPermissions;
+    }
+
+    /**
+     * Base permissions take precedence when explicitly set to allow or deny.
+     * Optimistic merging is used for nested permissions. Once allowed a permission stays allowed.
+     *
+     * @param array $mergedPermissions Already merged permissions
+     * @param array $basePermissions Permissions of the base object
+     * @param array $nestedPermissions Permissions of the nested object
+     * @return array Updated merged permissions
+     */
+    public function mergeNestedObjectPermissions(
+        array $mergedPermissions,
+        array $basePermissions,
+        array $nestedPermissions
+    ) {
+        foreach ($nestedPermissions as $key => $value) {
+            if (
+                (($basePermissions[$key] ?? null) === self::INHERIT || !array_key_exists($key, $basePermissions))
+                && ($mergedPermissions[$key] ?? null) !== self::ALLOW
+            ) {
+                $mergedPermissions[$key] = $value;
+            }
+        }
+
         return $mergedPermissions;
     }
 
@@ -136,9 +110,65 @@ class Service {
      * @param string $resource
      * @return bool
      */
-    public function isAllowed(Concrete $object, $resource): bool {
+    public function isAllowed(Concrete $object, $resource): bool
+    {
         $permissions = $this->getPermissions($object);
         return $permissions[$resource] == self::ALLOW;
     }
 
+    /**
+     * @param Concrete|Objectbrick\Data\AbstractData $object
+     * @param ClassDefinition\Data $fieldDefinition
+     * @return array
+     */
+    protected function getPermissionsByFieldDefinition(
+        AbstractModel $object,
+        ClassDefinition\Data $fieldDefinition
+    ): array {
+        $permissions = $permissionObjects = [];
+        switch (true) {
+            case ($fieldDefinition instanceof PermissionManyToManyRelation):
+                $permissionObjects = $object->get($fieldDefinition->getName());
+                break;
+
+            case ($fieldDefinition instanceof PermissionManyToOneRelation):
+                $manyToOneRelation = $object->get($fieldDefinition->getName());
+                if ($manyToOneRelation) {
+                    $permissionObjects = [$manyToOneRelation];
+                }
+                break;
+
+            case ($fieldDefinition instanceof PermissionResource):
+                $permissions = [$fieldDefinition->getName() => $object->get($fieldDefinition->getName())];
+                break;
+
+            case ($fieldDefinition instanceof DynamicPermissionResource):
+                $permissions = $object->get($fieldDefinition->getName());
+                break;
+
+            case (!$ignoreObjectBrickFields && $fieldDefinition instanceof ClassDefinition\Data\Objectbricks):
+                /* @var $objectBrick Objectbrick */
+                $objectBrick = $object->get($fieldDefinition->getName());
+                foreach ($objectBrick->getBrickGetters() as $brickGetter) {
+                    /* @var $brick Objectbrick\Data\AbstractData */
+                    $brick = $objectBrick->$brickGetter();
+                    if (!$brick) {
+                        continue;
+                    }
+
+                    $brickFieldDefinitions = $brick->getDefinition()->getFieldDefinitions();
+                    foreach ($brickFieldDefinitions as $brickFieldDefinition) {
+                        [$brickPermissions, $brickPermissionObjects] = $this->getPermissionsByFieldDefinition(
+                            $brick,
+                            $brickFieldDefinition
+                        );
+                        $permissions = array_merge($permissions, $brickPermissions);
+                        $permissionObjects = array_merge($permissionObjects, $brickPermissionObjects);
+                    }
+                }
+                break;
+        }
+
+        return [$permissions, $permissionObjects];
+    }
 }


### PR DESCRIPTION
Removed duplicate code used for both base object and nested brick field definitions
Split up logic into separate methods
Apply basic PSR-12 standards
Use AbstractObject and AbstractData get() methods to retrieve field values
Slightly updated merge logic:
- Prevent warning/notice in case the permission key doesn't exist
- Made operators strict
- Public method allows external usage