### PR TITLE
Do not persist dynamic permission resources in layout definitions

### DIFF
--- a/src/EventSubscriber/CustomLayoutSubscriber.php
+++ b/src/EventSubscriber/CustomLayoutSubscriber.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace FrontendPermissionToolkitBundle\EventSubscriber;
 
 use FrontendPermissionToolkitBundle\CoreExtensions\ClassDefinitions\DynamicPermissionResource;
@@ -28,9 +41,9 @@ final class CustomLayoutSubscriber implements EventSubscriberInterface
         $this->resetPermissionResources($customLayout->getLayoutDefinitions());
     }
 
-    private function resetPermissionResources(ClassDefinition\Data|ClassDefinition\Layout|null $layout): void
+    private function resetPermissionResources(ClassDefinition\Data | ClassDefinition\Layout | null $layout): void
     {
-        if($layout === null) {
+        if ($layout === null) {
             return;
         }
 

--- a/src/EventSubscriber/CustomLayoutSubscriber.php
+++ b/src/EventSubscriber/CustomLayoutSubscriber.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace FrontendPermissionToolkitBundle\EventSubscriber;
+
+use FrontendPermissionToolkitBundle\CoreExtensions\ClassDefinitions\DynamicPermissionResource;
+use Pimcore\Event\DataObjectCustomLayoutEvents;
+use Pimcore\Event\Model\DataObject\CustomLayoutEvent;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+final class CustomLayoutSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            DataObjectCustomLayoutEvents::PRE_ADD => 'onUpdate',
+            DataObjectCustomLayoutEvents::PRE_UPDATE => 'onUpdate',
+        ];
+    }
+
+    public function onUpdate(CustomLayoutEvent $event): void
+    {
+        $customLayout = $event->getCustomLayout();
+        $this->resetPermissionResources($customLayout->getLayoutDefinitions());
+    }
+
+    private function resetPermissionResources(ClassDefinition\Data|ClassDefinition\Layout|null $layout): void
+    {
+        if($layout === null) {
+            return;
+        }
+
+        if ($layout instanceof DynamicPermissionResource) {
+            $layout->setPermissionResources([]);
+        }
+        if (method_exists($layout, 'getChildren')) {
+            foreach ($layout->getChildren() ?? [] as $child) {
+                $this->resetPermissionResources($child);
+            }
+        }
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -7,3 +7,7 @@ services:
 
     bundle.frontendpermissiontoolkit.service:
         alias: FrontendPermissionToolkitBundle\Service
+
+    FrontendPermissionToolkitBundle\EventSubscriber\CustomLayoutSubscriber:
+        tags:
+            - { name: kernel.event_subscriber }


### PR DESCRIPTION
Do not persist dynamic permission resources in layout definitions as then the permission resources are not refreshed when the layout opens.

To apply this fix it's important to save the custom layouts where the problem happens again. Afterwards in the resulting YAML file or settings store entry the permission resources will be removed and with the empty list they will be loaded as soon as the layout get's opened.