### PR TITLE
[Bug]: newly added permissions should be inherit instead of empty

### DIFF
--- a/src/CoreExtensions/ClassDefinitions/DynamicPermissionResource.php
+++ b/src/CoreExtensions/ClassDefinitions/DynamicPermissionResource.php
@@ -136,6 +136,12 @@ class DynamicPermissionResource extends Data implements Data\ResourcePersistence
 
     public function getDataForEditmode(mixed $data, DataObject\Concrete $object = null, array $params = []): mixed
     {
+        $permissions = $this->getPermissionResources();
+        foreach ($permissions as $permission) {
+            if (!array_key_exists($permission['value'], $data)){
+                $data[$permission['value']] = Service::INHERIT;
+            }
+        }
         return $data;
     }
 

--- a/src/CoreExtensions/ClassDefinitions/DynamicPermissionResource.php
+++ b/src/CoreExtensions/ClassDefinitions/DynamicPermissionResource.php
@@ -138,10 +138,11 @@ class DynamicPermissionResource extends Data implements Data\ResourcePersistence
     {
         $permissions = $this->getPermissionResources();
         foreach ($permissions as $permission) {
-            if (!array_key_exists($permission['value'], $data)){
+            if (!array_key_exists($permission['value'], $data)) {
                 $data[$permission['value']] = Service::INHERIT;
             }
         }
+
         return $data;
     }
 


### PR DESCRIPTION
Noticed when working on https://github.com/pimcore/portal-engine/pull/501/files#diff-4543d8b4e324775b53fb69043df8a3ee626d3e461dec7825d8a2b1e98247c4c0R113-R117

Basically i have added a new permission and it appears as empty in the dropdown selection, assuming it has the same effect of `inherit`
![image](https://github.com/user-attachments/assets/6ee0f764-82a6-4c44-a9f6-b880943a10fd)

By default, they are all `inherit` on an ex-novo object, so only happens on existing objects.

Not sure if it's right or is it just a visual issue.