### PR TITLE
3207 - [FrontendPermissionToolkit] - Remove unnecessary quotes from German translations

### DIFF
--- a/src/Resources/translations/studio.de.yaml
+++ b/src/Resources/translations/studio.de.yaml
@@ -1,6 +1,6 @@
-field-definition.groups.data.frontend-permission-toolkit: "Frontend-Berechtigungs-Toolkit"
-field-definition.permission-resource: "Berechtigungsressource"
-field-definition.permission-many-to-one-relation: "Berechtigungsrelation Many-to-One"
-field-definition.permission-many-to-many-relation: "Berechtigungsrelation Many-to-Many"
-field-definition.dynamic-permission-resource: "Dynamische Berechtigungsressource"
-field-definition.dynamic-permission-resource.data-type: "Permission Resource Provider Service"
+field-definition.groups.data.frontend-permission-toolkit: Frontend-Berechtigungs-Toolkit
+field-definition.permission-resource: Berechtigungsressource
+field-definition.permission-many-to-one-relation: Berechtigungsrelation Many-to-One
+field-definition.permission-many-to-many-relation: Berechtigungsrelation Many-to-Many
+field-definition.dynamic-permission-resource: Dynamische Berechtigungsressource
+field-definition.dynamic-permission-resource.data-type: Permission Resource Provider Service


### PR DESCRIPTION
## Summary

- Remove unnecessary quotes from German translation values in studio.de.yaml
- Part of the translation QA review for #3207
- Only removes quotes that are not required by YAML syntax (simple text values)