### PR TITLE
Sync non-matrix workflows with 2026.x (#1305)

### DIFF
--- a/.github/workflows/studio-frontend-build.yml
+++ b/.github/workflows/studio-frontend-build.yml
@@ -1,5 +1,5 @@
 name: "Studio Frontend Build"
- 
+
 on:
   push:
     paths:
@@ -8,10 +8,16 @@ on:
     paths:
       - "assets/studio/**"
   workflow_dispatch:
- 
+
+concurrency:
+  group: studio-frontend-build-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
- 
+
 jobs:
   studio-frontend-build:
     uses: pimcore/workflows-collection-public/.github/workflows/reusable-studio-frontend-build.yaml@main
+    with:
+      build-output-path: './src/Resources/public/studio/'


### PR DESCRIPTION
Part of product-management#1305, Wave 1 (2026.2 branches). Same recipe as the approved pilots (generic-data-index-bundle, quill-bundle#99).

Every adopted file is **byte-identical** to this repo's `2026.x` version. Codeception / static-analysis workflows are deliberately untouched (matrix class). No 2026.x-only workflows (guardrails, symfony8-compat, copilot) are added.

Changes:` adopt:studio-frontend-build.yml(replaces new-studio-frontend-build.yml)`

After merge, the `2026.2 → 2026.x` forward-merge will be pushed directly (no PR) to keep ancestry clean for the release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)